### PR TITLE
send a single mail

### DIFF
--- a/index.js
+++ b/index.js
@@ -97,14 +97,13 @@ function processQueue() {
         }
       }
     }
-
-    sendMail({
-      subject: subject,
-      text: text,
-      attachments: attachments
-    })
   }
-
+  sendMail({
+    subject: subject,
+    text: text,
+    attachments: attachments
+  })
+    
   //reset queue
   queue.length = 0
 }


### PR DESCRIPTION
send a single mail when the timeout is greater than the time between events.

Right now, when multiple events fire inside a same 'timeout loop' it sends an email for each event. 
I believe your intent is to concatenate all of those events in a single mail, to prevent too much spam.